### PR TITLE
Adding support for when chocolatey was used to install nuget

### DIFF
--- a/chewie.ps1
+++ b/chewie.ps1
@@ -69,11 +69,11 @@ function chew
 		[string] $source = ""
 	)
 
-	$nuGetIsInPath = FileExistsInPath "NuGet.exe"
+	$nuGetIsInPath = (FileExistsInPath "NuGet.exe") -or (FileExistsInPath "NuGet.bat")
 	$command = ""
 	if($nuGetIsInPath) 
 	{
-		$command += "NuGet.exe install" 
+		$command += "NuGet install" 
 		if($script:version_packages -ne $true){$command += " -x"}
 		
 	} else { $command += "install-package"	}

--- a/chewie.psm1
+++ b/chewie.psm1
@@ -69,11 +69,11 @@ function chew
 		[string] $source = ""
 	)
 
-	$nuGetIsInPath = FileExistsInPath "NuGet.exe"
+	$nuGetIsInPath = (FileExistsInPath "NuGet.exe") -or (FileExistsInPath "NuGet.bat")
 	$command = ""
 		if($nuGetIsInPath) 
 	{
-		$command += "NuGet.exe install" 
+		$command += "NuGet install" 
 		if($script:version_packages -ne $true){$command += " -x"}
 		
 	} else { $command += "install-package"	}


### PR DESCRIPTION
By default, chewie looks for nuget.exe. When nuget.exe is not in the path, this of course fails. When chocolatey is installed, it adds nuget.bat to the path. If either nuget.exe or nuget.bat is in the path, then a call to "nuget install" will resolve the proper file to launch.
